### PR TITLE
Feat: add event location option to navbar (UI only)

### DIFF
--- a/src/core/components/header/Header.astro
+++ b/src/core/components/header/Header.astro
@@ -63,6 +63,7 @@ const data = YEAR_DATA[selectedYear] || YEAR_DATA['2025']
           <li class="nav-item"><a href="#about">Sobre FLISoL</a></li>
           <li class="nav-item"><a href="#agenda">Agenda</a></li>
           <li class="nav-item"><a href="#contact">Contacto</a></li>
+          <li class="nav-item"><a href="#eventLocation">Ubicación</a></li> 
           <li class="nav-item"><a href="#contributors">Contributors</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
In this pull request, my idea is to add a location option for the event. As the commit indicates, I added the location option to the navigation bar in the user interface, with the purpose of redirecting (later) to a component (page) that displays the event's location (a map).
I felt it was necessary to add this feature because the event spans two days, and it's helpful to guide participants and interested parties with a map directing them to the venue.