### PR TITLE
Feature (content): Add about section

### DIFF
--- a/src/core/components/header/Header.astro
+++ b/src/core/components/header/Header.astro
@@ -189,6 +189,42 @@ const data = YEAR_DATA[selectedYear] || YEAR_DATA['2025']
     transition: color 0.3s ease;
   }
 
+  .nav-item a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 0%;
+    height: 2px;
+    background: var(--arrowColor);
+    transition: width 0.3s ease;
+  }
+
+  .nav-item a:hover::after {
+    width: 100%;
+  }
+
+  .nav-item a:hover {
+    color: var(--arrowColor);
+  }
+
+  .register-button a {
+    background-color: var(--arrowColor);
+    color: black;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    border: 3px solid black;
+    box-shadow: 4px 4px 0px black;
+    transition: all 0.2s ease;
+  }
+
+  .register-button a:hover {
+    background-color: #6d28d9;
+    color: white;
+    transform: translateY(-2px);
+    box-shadow: 6px 6px 0px black;
+  }
+  
   .register-button a {
     background-color: var(--arrowColor);
     color: black;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import Layout from '@/v2026/layouts/Layout.astro'
 import '@/globals.css'
 
 import Hero2026 from '@/v2026/components/sections/Hero-2026.astro'
+import Content2026 from '@/v2026/components/Content-2026.astro'
 
 const CurrentYear = new Date().getFullYear()
 ---
@@ -10,6 +11,6 @@ const CurrentYear = new Date().getFullYear()
 <Layout>
 
   <Hero2026 />
-  <!-- <Content2026 /> -->
+  <Content2026 />
 
 </Layout>

--- a/src/v2026/components/Content-2026.astro
+++ b/src/v2026/components/Content-2026.astro
@@ -1,0 +1,136 @@
+---
+import RunTux from '@/v2025/assets/icons/svg/run-tux.svg'
+---
+
+<div class="content-container">
+  <div class="title">
+    <span>FLISOL 2026</span>
+  </div>
+
+  <div class="about-event image-container" id="about">
+    <RunTux />
+  </div>
+
+  <div class="about-event-dark dark-box">
+    <div>
+      <h3 class="dark-title">Sobre el evento</h3>
+      <p class="dark-description">
+        El FLISoL (Festival Latinoamericano de Instalación de Software Libre) es un evento anual que
+        busca difundir y <span class="highlighted">promover el Software Libre en Latinoamérica</span>.
+        Es el evento de difusión de Software Libre más grande en el mundo hispanohablante.
+      </p>
+    </div>
+  </div>
+</div>
+
+<style lang="scss">
+.content-container {
+  position: relative;
+  margin: 0;
+  padding: 3rem 2rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1rem;
+
+  /* Se añadió para tener un fondo continuo con Hero-2026.astro */
+  background: linear-gradient(to bottom, #210a50 0%, #1a073d 100%);
+  overflow: hidden;
+}
+
+/* GRID overlay (continuidad con Hero-2026) */
+.content-container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(66, 150, 202, 0.05) 1px, transparent 1px),
+    linear-gradient(to right, rgba(66, 150, 202, 0.05) 1px, transparent 1px);
+  background-size: 40px 40px;
+  pointer-events: none;
+}
+
+.content-container::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 0%, rgba(66,150,202,0.15), transparent 70%);
+  pointer-events: none;
+}
+
+.title {
+  grid-column: 1 / 7;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.title span {
+  color: #efe524;
+  font-size: 4rem;
+  text-align: center;
+  -webkit-text-stroke: 2px black;
+  text-shadow:
+    0 0 10px #4296ca,
+    0 0 20px #4296ca,
+    4px 4px black;
+}
+
+.image-container,
+.dark-box {
+  backdrop-filter: blur(6px);
+  border: 2px solid rgba(66, 150, 202, 0.4);
+  box-shadow: 0 0 15px rgba(66, 150, 202, 0.3);
+  border-radius: 10px;
+}
+
+.about-event {
+  grid-column: 1 / 3;
+  min-height: 350px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(33, 10, 80, 0.4);
+}
+
+.about-event-dark {
+  grid-column: 3 / 7;
+  padding: 2rem;
+  background: rgba(33, 10, 80, 0.6);
+}
+
+.dark-title {
+  color: #efe524;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  text-shadow: 0 0 10px rgba(66, 150, 202, 0.8);
+}
+
+.dark-description {
+  color: #e0e0ff;
+  font-size: 1.2rem;
+  line-height: 1.6;
+}
+
+.highlighted {
+  color: #efe524;
+  font-weight: bold;
+}
+
+@media screen and (max-width: 768px) {
+  .content-container {
+    display: flex;
+    flex-direction: column;
+    padding: 2rem 1rem;
+  }
+
+  .title span {
+    font-size: 2.5rem;
+  }
+
+  .about-event,
+  .about-event-dark {
+    width: 100%;
+  }
+}
+</style>


### PR DESCRIPTION
In this pull request, I wanted to contribute by adding the "Sobre FLISoL" section. To do this, I created the Content-2026.astro component (located in: src\v2026\components\Content-2026.astro) and added only the "About FLISoL" section and its content. I also reused the image (icon) from v2025 (RunTux from '@/v2025/assets/icons/svg/run-tux.svg'), based on a structure similar to that of v2025 in terms of position, id, classnames, etc.