### PR TITLE
Fix (footer): Update year to 2026

### DIFF
--- a/src/core/components/footer/Footer.astro
+++ b/src/core/components/footer/Footer.astro
@@ -86,7 +86,7 @@ import LinkedinLogo from '@/core/assets/logos/socials/linkedin-logo.svg'
         </ul>
       </article>
     </div>
-    <p>&copy; 2025 The Open Source Contributors. MIT Licensed.</p>
+    <p>&copy; 2026 The Open Source Contributors. MIT Licensed.</p>
   </div>
 
   <style>


### PR DESCRIPTION
## Changes
- Updated footer year from 2025 to 2026.

## Notes
- This change ensures the footer displays the correct current year.